### PR TITLE
feat: implement Maximum Variance Analysis on Electric Field (MVAE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [SPEDAS](https://juliaspacephysics.github.io/SPEDAS.jl/dev/explanations/coor
 ## Roadmap
 
 - [ ] Minimum Variance Analysis on Mass Flux (MVAρv)
-- [ ] Maximum Variance Analysis on Electric Field (MVAE)
+- [x] Maximum Variance Analysis on Electric Field (MVAE)
 - [ ] Application to 2-D Structures
 
 ## Notes

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,4 +14,5 @@ Error estimates for MVA:
 ```@docs; canonical=false
 MinimumVarianceAnalysis.Δφij
 MinimumVarianceAnalysis.B_x3_error
+MinimumVarianceAnalysis.E_x1_error
 ```

--- a/ext/MVADimensionalDataExt.jl
+++ b/ext/MVADimensionalDataExt.jl
@@ -1,5 +1,5 @@
 module MVADimensionalDataExt
-import MinimumVarianceAnalysis: mva_eigen, _dimnum
+import MinimumVarianceAnalysis: mva_eigen, mvae_eigen, _dimnum
 using DimensionalData: AbstractDimArray, dimnum, hasdim, TimeDim
 
 function _dimnum(x::AbstractDimArray, query = nothing)
@@ -14,5 +14,10 @@ end
 function mva_eigen(A::AbstractDimArray; dim = nothing, query = nothing, kw...)
     dim = @something dim _dimnum(A, query)
     return mva_eigen(parent(A); dim, kw...)
+end
+
+function mvae_eigen(A::AbstractDimArray; dim = nothing, query = nothing, kw...)
+    dim = @something dim _dimnum(A, query)
+    return mvae_eigen(parent(A); dim, kw...)
 end
 end

--- a/src/MinimumVarianceAnalysis.jl
+++ b/src/MinimumVarianceAnalysis.jl
@@ -7,6 +7,7 @@ using LinearAlgebra
 using StaticArrays
 using Unitful: Quantity, ustrip, unit
 export mva, mva_eigen, check_mva_eigen
+export mvae, mvae_eigen, check_mvae_eigen, convection_efield
 
 const SV3 = SVector{3}
 
@@ -125,6 +126,7 @@ end
 
 B_x3_error(F::Eigen, M, B) = B_x3_error(F.values..., M, B, eachcol(F.vectors)...)
 
+include("mvae.jl")
 include("workload.jl")
 
 end

--- a/src/mvae.jl
+++ b/src/mvae.jl
@@ -1,0 +1,121 @@
+# Maximum Variance Analysis of Electric Field (MVAE)
+# Reference: Sonnerup, B. U. Ö., & Scheible, M. (1998). Minimum and maximum variance analysis.
+#            ISSI Scientific Reports Series, 1, 185–220.
+
+"""
+    convection_efield(v, B; dim=nothing)
+
+Compute the convection electric field ``\\mathbf{E} = -\\mathbf{v} × \\mathbf{B}`` from
+plasma velocity `v` and magnetic field `B`.
+
+This can be used as a proxy for the measured electric field when direct measurements are
+unavailable (Sonnerup et al., 1987).
+
+See also: [`mvae`](@ref), [`mvae_eigen`](@ref)
+"""
+function convection_efield(v, B; dim = nothing)
+    dim = something(dim, 1)
+    v_in = dim == 1 ? v : v'
+    B_in = dim == 1 ? B : B'
+    E = stack(-cross3(view(v_in, i, :), view(B_in, i, :)) for i in axes(v_in, 1); dims = 1)
+    return dim == 1 ? E : E'
+end
+
+"""
+    mvae_eigen(E::AbstractMatrix; dim=nothing, sort=(;), check=false) -> F::Eigen
+
+Perform maximum variance analysis of the electric field `E` (Sonnerup & Scheible, 1998).
+
+For a one-dimensional current layer, the tangential electric field components are
+approximately constant across the boundary, while the normal component exhibits the
+largest variation. Therefore, the eigenvector corresponding to the **maximum eigenvalue**
+``λ_1`` (first column of `F.vectors`) gives an estimate of the boundary normal direction.
+
+Return `Eigen` factorization object `F` which contains the eigenvalues in `F.values`
+and the eigenvectors in the columns of the matrix `F.vectors`.
+
+Set `check=true` to check the reliability of the result.
+
+See also: [`mvae`](@ref), [`check_mvae_eigen`](@ref), [`convection_efield`](@ref)
+"""
+function mvae_eigen(E; dim = nothing, sort = (;), check = false)
+    dim = something(dim, 1)
+    in = dim == 1 ? E : E'
+    N = size(in, 2)
+    F = _mva_eigen(in, Val(N); sort)
+    check && check_mvae_eigen(F)
+    return F
+end
+
+function mvae_eigen(E::AbstractMatrix{Q}; kwargs...) where {Q <: Quantity}
+    F = mvae_eigen(ustrip(E); kwargs...)
+    return Eigen(F.values * unit(Q)^2, F.vectors)
+end
+
+"""
+    mvae(V, E=V; dim=nothing, kwargs...)
+
+Transform a timeseries `V` into the coordinate system obtained from maximum variance
+analysis of electric field `E` along the `dim` dimension (time).
+
+The columns of the result correspond to: maximum variance (normal), intermediate,
+and minimum variance directions.
+
+See also: [`mvae_eigen`](@ref), [`convection_efield`](@ref), [`transform`](@ref)
+"""
+function mvae(V, E = V; dim = nothing, kwargs...)
+    F = mvae_eigen(E; dim, kwargs...)
+    return transform(V, F; dim)
+end
+
+"""
+    check_mvae_eigen(F; r0=5, verbose=false)
+
+Check the quality of the MVAE result.
+
+For MVAE, a reliable normal direction requires the maximum eigenvalue ``λ_1`` to be
+well-separated from the intermediate eigenvalue ``λ_2``. The ratio ``|λ_1 / λ_2| > r_0``
+is used as a quality indicator (default ``r_0 = 5``).
+
+See also: [`mvae_eigen`](@ref)
+"""
+function check_mvae_eigen(F; r0 = 5, verbose = false)
+    r = abs(F.values[1] / F.values[2])
+    flag = r > r0
+    verbose && begin
+        println(F.vectors)
+        println("Ratio of maximum variance to intermediate variance = ", r)
+        flag && @info "Seems to be a proper MVAE attempt!"
+    end
+    flag || @warn "Take the MVAE result with a grain of salt!"
+    return flag
+end
+
+################
+# Error Estimate
+################
+
+"""
+    E_x1_error(λ₁, λ₂, λ₃, M, E, x₁, x₂, x₃)
+
+Calculate the composite statistical error estimate for ⟨E·x₁⟩ (the mean electric field
+along the maximum variance / normal direction):
+
+``|Δ⟨\\mathbf{E}·\\mathbf{x}_1⟩| = \\sqrt{\\frac{λ_1}{M-1} + (Δφ_{12}⟨\\mathbf{E}⟩·\\mathbf{x}_2)^2 + (Δφ_{13}⟨\\mathbf{E}⟩·\\mathbf{x}_3)^2}``
+
+Parameters:
+
+  - λ₁, λ₂, λ₃: eigenvalues in descending order
+  - M: number of samples
+  - E: mean electric field vector
+  - x₁, x₂, x₃: eigenvectors
+"""
+function E_x1_error(λ₁, λ₂, λ₃, M, E, x₁, x₂, x₃)
+    Δφ₁₂ = Δφij(λ₁, λ₂, λ₃, M)
+    Δφ₁₃ = Δφij(λ₁, λ₃, λ₃, M)
+    E_x₂ = dot(E, x₂)
+    E_x₃ = dot(E, x₃)
+    return sqrt(λ₁ / (M - 1) + (Δφ₁₂ * E_x₂)^2 + (Δφ₁₃ * E_x₃)^2)
+end
+
+E_x1_error(F::Eigen, M, E) = E_x1_error(F.values..., M, E, eachcol(F.vectors)...)

--- a/src/workload.jl
+++ b/src/workload.jl
@@ -5,5 +5,7 @@ using Unitful: nT
     B = rand(10, 3) .* nT
     @compile_workload begin
         mva(B)
+        mvae(B)
+        convection_efield(rand(10, 3), rand(10, 3))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,142 @@ end
     @test F_const.values == [0, 0, 0]
 end
 
+@testitem "mvae_eigen basic functionality with synthetic data" begin
+    using LinearAlgebra
+    using DimensionalData
+    using Unitful
+
+    # Create synthetic E-field data with known variance structure
+    # Normal component (max variance) along z, tangential components (low variance) along x, y
+    En = cosd.(0:30:180)
+    Et1 = 0.1 .* ones(7)
+    Et2 = 0.05 .* ones(7)
+    E = hcat(Et1, Et2, En)
+
+    F = mvae_eigen(E; check = true)
+
+    # Check that we get 3 eigenvalues and 3 eigenvectors
+    @test length(F.values) == 3
+    @test size(F.vectors) == (3, 3)
+    # Check that eigenvalues are sorted in descending order (default behavior)
+    @test F.values[1] >= F.values[2] >= F.values[3]
+    # Maximum variance direction (column 1) should be the z-axis (normal)
+    @test F.vectors[:, 1] ≈ [0.0, 0.0, 1.0] || F.vectors[:, 1] ≈ [0.0, 0.0, -1.0]
+    # Check that eigenvectors are orthonormal
+    @test F.vectors' * F.vectors ≈ I
+    @test abs(det(F.vectors)) ≈ 1
+    # Check transformation
+    @test mvae(E) .* diag(F.vectors)' ≈ E
+
+    # Dimensional data
+    E1 = DimArray(E * u"mV/m", (Ti(0:6), Y(1:3)))
+    E2 = DimArray(collect(E') * u"mV/m", (Y(1:3), Ti(0:6)))
+    F1 = mvae_eigen(E1)
+    F2 = mvae_eigen(E2)
+    @test F1.values ≈ F2.values
+    @test F1.vectors ≈ F2.vectors
+
+    # Test with dim=2
+    E_t = collect(E')
+    Ft = mvae_eigen(E_t; dim = 2)
+    @test Ft.values ≈ F.values
+    @test Ft.vectors ≈ F.vectors
+
+    # Test edge case: constant field
+    E_const = ones(10, 3)
+    F_const = mvae_eigen(E_const)
+    @test F_const.values == [0, 0, 0]
+end
+
+@testitem "check_mvae_eigen quality check" begin
+    using LinearAlgebra: Eigen
+
+    # Good MVAE: well-separated maximum eigenvalue
+    F_good = Eigen([100.0, 5.0, 1.0], [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+    @test check_mvae_eigen(F_good; r0 = 5) == true
+
+    # Bad MVAE: poorly separated eigenvalues
+    F_bad = Eigen([3.0, 2.5, 1.0], [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
+    @test check_mvae_eigen(F_bad; r0 = 5) == false
+end
+
+@testitem "convection_efield" begin
+    using LinearAlgebra
+
+    # v = [1,0,0], B = [0,1,0] → E = -v×B = -(0,0,1) = [0,0,-1]
+    # v = [0,1,0], B = [1,0,0] → E = -v×B = -(0,0,-1) = [0,0,1]
+    v = [1.0 0.0 0.0; 0.0 1.0 0.0]
+    B = [0.0 1.0 0.0; 1.0 0.0 0.0]
+    E = convection_efield(v, B)
+    @test E ≈ [0.0 0.0 -1.0; 0.0 0.0 1.0]
+
+    # Test with dim=2
+    E2 = convection_efield(collect(v'), collect(B'); dim = 2)
+    @test E2 ≈ collect(E')
+
+    # Test that E = -v × B satisfies the identity: v ⋅ E = 0
+    v3 = randn(20, 3)
+    B3 = randn(20, 3)
+    E3 = convection_efield(v3, B3)
+    for i in axes(v3, 1)
+        @test dot(view(v3, i, :), view(E3, i, :)) ≈ 0.0 atol = 1e-12
+    end
+end
+
+@testitem "mvae with convection_efield integration" begin
+    using LinearAlgebra
+
+    # Create a scenario where the normal direction (z) has large E variation
+    # and tangential directions have small E variation
+    n = 50
+    t = range(0, π, length = n)
+
+    # Plasma velocity: mostly in x-direction, varying magnitude
+    v = hcat(10.0 .* cos.(t), 0.5 .* ones(n), 0.2 .* ones(n))
+
+    # Magnetic field: mostly in y-direction
+    B = hcat(0.1 .* ones(n), 5.0 .* sin.(t), 0.3 .* ones(n))
+
+    # Compute convection E-field
+    E = convection_efield(v, B)
+    @test size(E) == (n, 3)
+
+    # Should be able to run MVAE on this
+    F = mvae_eigen(E)
+    @test length(F.values) == 3
+    @test F.values[1] >= F.values[2] >= F.values[3]
+    @test F.vectors' * F.vectors ≈ I
+
+    # Transform should preserve dimensions
+    E_transformed = mvae(E)
+    @test size(E_transformed) == size(E)
+end
+
+@testitem "E_x1_error" begin
+    using LinearAlgebra
+    using MinimumVarianceAnalysis: E_x1_error, Δφij
+
+    λ₁, λ₂, λ₃ = 10.0, 2.0, 0.5
+    M = 100
+    E = [1.0, 0.5, 0.1]
+    x₁ = [1.0, 0.0, 0.0]
+    x₂ = [0.0, 1.0, 0.0]
+    x₃ = [0.0, 0.0, 1.0]
+
+    err = E_x1_error(λ₁, λ₂, λ₃, M, E, x₁, x₂, x₃)
+    @test err > 0
+    @test isfinite(err)
+
+    # Test convenience method with Eigen
+    F = Eigen([λ₁, λ₂, λ₃], hcat(x₁, x₂, x₃))
+    err2 = E_x1_error(F, M, E)
+    @test err ≈ err2
+
+    # Error should increase with fewer samples
+    err_fewer = E_x1_error(λ₁, λ₂, λ₃, 10, E, x₁, x₂, x₃)
+    @test err_fewer > err
+end
+
 @testitem "right-handed coordinate system check" begin
     using LinearAlgebra: Eigen
     using MinimumVarianceAnalysis: is_right_handed


### PR DESCRIPTION
Add MVAE algorithm following Sonnerup & Scheible (1998). For a 1D current layer, the normal direction has maximum electric field variance (unlike MVAB where the normal has minimum magnetic field variance).

New public API:
- mvae_eigen(E): eigendecomposition with max eigenvalue = normal direction
- mvae(V, E): transform timeseries to MVAE coordinate system
- check_mvae_eigen(F): quality check using λ₁/λ₂ ratio
- convection_efield(v, B): compute E = -v×B proxy electric field

Also adds E_x1_error for MVAE error estimation, DimensionalData extension support, and comprehensive tests.

https://claude.ai/code/session_01NJD1MCzbYteJBHoFu6K3vC